### PR TITLE
Case insensitve dimension match for resource association

### DIFF
--- a/pkg/config/services.go
+++ b/pkg/config/services.go
@@ -50,7 +50,9 @@ func (sc ServiceConfig) ToModelDimensionsRegexp() []model.DimensionsRegexp {
 		// skip first name, it's always an empty string
 		for i := 1; i < len(names); i++ {
 			// in the regex names we use underscores where AWS dimensions have spaces
-			dimensionNames = append(dimensionNames, strings.ReplaceAll(names[i], "_", " "))
+			// Lower case dimension names as some of the AWS services have different cases, e.g.
+			// RDS has both DBInstanceIdentifier and DbInstanceIdentifier.
+			dimensionNames = append(dimensionNames, strings.ToLower(strings.ReplaceAll(names[i], "_", " ")))
 		}
 
 		dr = append(dr, model.DimensionsRegexp{

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -211,7 +211,7 @@ func metricDimensionsMatchNames(metric *model.Metric, dimensionNameRequirements 
 	for _, dimension := range metric.Dimensions {
 		foundMatch := false
 		for _, dimensionName := range dimensionNameRequirements {
-			if dimension.Name == dimensionName {
+			if strings.EqualFold(dimension.Name, dimensionName) {
 				foundMatch = true
 				break
 			}

--- a/pkg/job/maxdimassociator/associator.go
+++ b/pkg/job/maxdimassociator/associator.go
@@ -100,7 +100,7 @@ func NewAssociator(logger *slog.Logger, dimensionsRegexps []model.DimensionsRege
 
 			labels := make(map[string]string, len(match))
 			for i := 1; i < len(match); i++ {
-				labels[dr.DimensionsNames[i-1]] = match[i]
+				labels[strings.ToLower(dr.DimensionsNames[i-1])] = match[i]
 			}
 			signature := prom_model.LabelsToSignature(labels)
 			m.dimensionsMapping[signature] = r
@@ -234,8 +234,8 @@ func buildLabelsMap(cwMetric *model.Metric, regexpMapping *dimensionsRegexpMappi
 				mDimension, dimFixApplied = fixDimension(cwMetric.Namespace, mDimension)
 			}
 
-			if rDimension == mDimension.Name {
-				labels[mDimension.Name] = mDimension.Value
+			if strings.EqualFold(rDimension, mDimension.Name) {
+				labels[strings.ToLower(mDimension.Name)] = mDimension.Value
 			}
 		}
 	}
@@ -269,9 +269,12 @@ func fixDimension(namespace string, dim model.Dimension) (model.Dimension, bool)
 // containsAll returns true if a contains all elements of b
 func containsAll(a, b []string) bool {
 	for _, e := range b {
-		if slices.Contains(a, e) {
+		if slices.ContainsFunc(a, func(s string) bool {
+			return strings.EqualFold(s, e)
+		}) {
 			continue
 		}
+
 		return false
 	}
 	return true


### PR DESCRIPTION
RDS has CW metrics under both `DBClusterIdentifier` and `DbClusterIdentifier`. Lower case dimensions so that both metrics can be associated to appropriate resources