### PR TITLE
Add option to scrape data for all metrics in a namspace

### DIFF
--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -220,6 +220,9 @@ func getFilteredMetricDatas(
 			djMetric = &model.MetricConfig{
 				Name:       cwMetric.MetricName,
 				Statistics: defaultStatistics,
+				Period:     defaultDiscoveryJobPeriod,
+				Length:     defaultDiscoveryJobLength,
+				Delay:      defaultDiscoveryJobDelay,
 			}
 		}
 
@@ -290,9 +293,9 @@ func getFilteredMetricDatas(
 					Namespace:    namespace,
 					Dimensions:   cwMetric.Dimensions,
 					GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
-						Period:    defaultDiscoveryJobPeriod,
-						Length:    defaultDiscoveryJobLength,
-						Delay:     defaultDiscoveryJobDelay,
+						Period:    djMetric.Period,
+						Length:    djMetric.Length,
+						Delay:     djMetric.Delay,
 						Statistic: stat,
 					},
 					MetricMigrationParams: model.MetricMigrationParams{

--- a/pkg/job/discovery.go
+++ b/pkg/job/discovery.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"strings"
 
+	awstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients/cloudwatch"
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/clients/tagging"
 	"github.com/prometheus-community/yet-another-cloudwatch-exporter/pkg/config"
@@ -37,6 +38,24 @@ type getMetricDataProcessor interface {
 type metricInfo struct {
 	cwMetric   *model.Metric
 	metricConf *model.MetricConfig
+}
+
+const (
+	defaultDiscoveryJobPeriod = 60
+	// Below 2 settings effectively mean that we query metric data for `[now-15m, now-5m]` range
+	// This avoids any gaps in metric data in case of small delays in scheduling. Each scrape cycle
+	// runs every 5m, so 2 consecutive scrape cycle has an overlap of 5m window for which both scrape
+	// cycles will pull the data. This assumes de-duplication is handled during ingestion.
+	defaultDiscoveryJobLength = 600
+	defaultDiscoveryJobDelay  = 300
+)
+
+var defaultStatistics = []string{
+	string(awstypes.StatisticAverage),
+	string(awstypes.StatisticSum),
+	string(awstypes.StatisticSampleCount),
+	string(awstypes.StatisticMaximum),
+	string(awstypes.StatisticMinimum),
 }
 
 func runDiscoveryJob(
@@ -119,6 +138,7 @@ func getMetricDataForQueries(
 			assoc,
 			hasSearchTags,
 			discoveryJob.DedupeResourceMetrics,
+			discoveryJob.IncludeAllMetrics,
 			metricNameResourceToMetricMap,
 			globalResource,
 		)
@@ -180,6 +200,7 @@ func getFilteredMetricDatas(
 	assoc resourceAssociator,
 	hasSearchTags bool,
 	dedupeResourceMetrics bool,
+	includeAllMetrics bool,
 	metricNameResourceToMetricMap map[string]map[*model.TaggedResource][]*metricInfo,
 	globalResource *model.TaggedResource,
 ) []*model.CloudwatchData {
@@ -192,7 +213,14 @@ func getFilteredMetricDatas(
 	for _, cwMetric := range metricsList {
 		djMetric, ok := metricNameToDiscoveryJobMetricConfig[cwMetric.MetricName]
 		if !ok {
-			continue
+			if !includeAllMetrics {
+				continue
+			}
+
+			djMetric = &model.MetricConfig{
+				Name:       cwMetric.MetricName,
+				Statistics: defaultStatistics,
+			}
 		}
 
 		if len(dimensionNameList) > 0 && !metricDimensionsMatchNames(cwMetric, dimensionNameList) {
@@ -262,9 +290,9 @@ func getFilteredMetricDatas(
 					Namespace:    namespace,
 					Dimensions:   cwMetric.Dimensions,
 					GetMetricDataProcessingParams: &model.GetMetricDataProcessingParams{
-						Period:    djMetric.Period,
-						Length:    djMetric.Length,
-						Delay:     djMetric.Delay,
+						Period:    defaultDiscoveryJobPeriod,
+						Length:    defaultDiscoveryJobLength,
+						Delay:     defaultDiscoveryJobDelay,
 						Statistic: stat,
 					},
 					MetricMigrationParams: model.MetricMigrationParams{

--- a/pkg/job/discovery_test.go
+++ b/pkg/job/discovery_test.go
@@ -428,6 +428,11 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			metricNameResourceToMetricMap := make(map[string]map[*model.TaggedResource][]*metricInfo)
+			globalResource := &model.TaggedResource{
+				ARN:       "global",
+				Namespace: tt.args.namespace,
+			}
 			assoc := maxdimassociator.NewAssociator(promslog.NewNopLogger(), tt.args.dimensionRegexps, tt.args.resources)
 			metricDatas := getFilteredMetricDatas(
 				promslog.NewNopLogger(),
@@ -437,7 +442,11 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				tt.args.metricsConfig,
 				tt.args.dimensionNameRequirements,
 				assoc,
-				false, /* hasSearchTags */
+				false, // hasSearchTags
+				false, // dedupResourceMetrics
+				false, // includeAllMetrics
+				metricNameResourceToMetricMap,
+				globalResource,
 			)
 			if len(metricDatas) != len(tt.wantGetMetricsData) {
 				t.Errorf("len(getFilteredMetricDatas()) = %v, want %v", len(metricDatas), len(tt.wantGetMetricsData))

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -44,6 +44,7 @@ type DiscoveryJob struct {
 	IncludeContextOnInfoMetrics bool
 	DimensionsRegexps           []DimensionsRegexp
 	DedupeResourceMetrics       bool
+	IncludeAllMetrics           bool
 }
 
 type StaticJob struct {


### PR DESCRIPTION
If includeAllMetrics flag is set to true, scrape data for all metrics in a namspace with default config. This will scrape data for all statistics.